### PR TITLE
fix path in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include CHANGES
-include README.md
+include CHANGES.rst
+include README.rst
 include UNLICENSE


### PR DESCRIPTION
The files `CHANGES` and `README.md` have been renamed to `CHANGES.rst` and `README.rst`.

With the files missing in the published package you get errors installing it.