### PR TITLE
fix:toggle_query support when one word is a fragment of the other

### DIFF
--- a/spurl/templatetags/spurl.py
+++ b/spurl/templatetags/spurl.py
@@ -119,7 +119,7 @@ class SpurlURLBuilder(object):
             if isinstance(value, six.string_types):
                 value = value.split(",")
             first, second = value
-            if key in current_query and first in current_query[key]:
+            if key in current_query and first == current_query[key]:
                 self.url = self.url.set_query_param(key, second)
             else:
                 self.url = self.url.set_query_param(key, first)

--- a/spurl/tests.py
+++ b/spurl/tests.py
@@ -248,6 +248,11 @@ def test_toggle_query():
     rendered = render(template, data)
     assert rendered == "http://www.google.com/?foo=bar&bar=first"
 
+    template = """{% spurl base="http://www.google.com/?foo=bar&bar=javascript" toggle_query=to_toggle %}"""
+    data = {"to_toggle": {"bar": ("java", "javascript")}}
+    rendered = render(template, data)
+    assert rendered == "http://www.google.com/?foo=bar&bar=java"
+
 
 def test_multiple_set_query():
     template = """{% spurl base="http://www.google.com/?foo=test" set_query="foo=bar" set_query="bar=baz" %}"""


### PR DESCRIPTION
Hello dear all,

I've noticed toggle_query doesn't work as expected when toggling between words for which one might be a fragment/segment of the other e.g. "java" and "javavascript" or "cost" and "-cost".
The logic today uses "in" which works for most cases but not this particular one.
The pull request is then to replace that "in" with "=="

One test case also added.

I have been using this change in my projects already but was thinking someone else might bump into this

Cheers,
Remi